### PR TITLE
listSearchResultタグをUniversalDaoの検索結果をそのまま表示できるよう修正

### DIFF
--- a/node_modules/nablarch-dev-ui_demo-core-lib/ui_local/js/jsp/el.js
+++ b/node_modules/nablarch-dev-ui_demo-core-lib/ui_local/js/jsp/el.js
@@ -47,7 +47,12 @@ function(Consumer, jstlFunctions) { 'use strict';
       , v;
     c.data = context;
     v = expression(c);
-    return v[0];
+    if(v) {
+      return v[0];
+    }
+    else {
+      return null;
+    }
   }
 
   /**

--- a/node_modules/nablarch-template-multicol-head/ui_test/jsp/マルチカラムレイアウト/デモページ/検索画面_データ.jsp
+++ b/node_modules/nablarch-template-multicol-head/ui_test/jsp/マルチカラムレイアウト/デモページ/検索画面_データ.jsp
@@ -8,6 +8,7 @@
 <%@ page import="java.util.List" %>
 <%@ page import="java.util.Locale" %>
 <%@ page import="java.util.Map" %>
+<%@ page import="nablarch.common.dao.EntityList" %>
 <%@ page import="nablarch.core.message.ApplicationException" %>
 <%@ page import="nablarch.core.message.StringResource" %>
 <%@ page import="nablarch.core.validation.ValidationResultMessage" %>
@@ -42,15 +43,19 @@
     request.setAttribute("nablarch_application_error", applicationException);
   } else {
 
-    List<Map<String, String>> result = new ArrayList<Map<String, String>>();
-    for (int i = 0; i < 15; i++) {
-      Map<String, String> row = new HashMap<String, String>();
-      int rowNumber = i + 1;
-      row.put("kanjiName", "漢字名_" + rowNumber);
-      row.put("kanaName", "カナメイ_" + rowNumber);
-      row.put("birthday", generateDate(rowNumber));
-      result.add(row);
-    }
+    EntityList<Map<String, String>> result = new EntityList<Map<String, String>>() {{
+      for (int i = 0; i < 15; i++) {
+        Map<String, String> row = new HashMap<String, String>();
+        int rowNumber = i + 1;
+        row.put("kanjiName", "漢字名_" + rowNumber);
+        row.put("kanaName", "カナメイ_" + rowNumber);
+        row.put("birthday", generateDate(rowNumber));
+        result.add(row);
+      }
+      setPage(1);
+      setMax(15);
+      setResultCount(15);
+    }};
 
     request.setAttribute("searchResult", result);
   }

--- a/node_modules/nablarch-widget-column-checkbox/ui_test/jsp/テーブル/カラムウィジェット_チェックボックス_テストデータ.jsp
+++ b/node_modules/nablarch-widget-column-checkbox/ui_test/jsp/テーブル/カラムウィジェット_チェックボックス_テストデータ.jsp
@@ -1,8 +1,7 @@
-<%@ page import="java.util.ArrayList" %>
 <%@ page import="java.util.HashMap" %>
-<%@ page import="java.util.List" %>
 <%@ page import="java.util.Map" %>
 <%@ page import="nablarch.core.db.support.ListSearchInfo" %>
+<%@ page import="nablarch.common.dao.EntityList" %>
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
 
 <!--
@@ -32,7 +31,7 @@
     }
   }
 
-  List<Map<String, Object>> result = new ArrayList<Map<String, Object>>() {{
+  EntityList<Map<String, Object>> result = new EntityList<Map<String, Object>>() {{
     add(new HashMap<String, Object>() {{
       put("id", "1001");
       put("name", "なまえ");
@@ -61,6 +60,9 @@
       put("date", "20131004");
       put("number", 1000000);
     }});
+    setPage(1);
+    setMax(size());
+    setResultCount(size());
   }};
 
   request.setAttribute("result", result);

--- a/node_modules/nablarch-widget-column-code/ui_test/jsp/テーブル/カラムウィジェット_コード_テストデータ.jsp
+++ b/node_modules/nablarch-widget-column-code/ui_test/jsp/テーブル/カラムウィジェット_コード_テストデータ.jsp
@@ -1,8 +1,7 @@
-<%@ page import="java.util.ArrayList" %>
 <%@ page import="java.util.HashMap" %>
-<%@ page import="java.util.List" %>
 <%@ page import="java.util.Map" %>
 <%@ page import="nablarch.core.db.support.ListSearchInfo" %>
+<%@ page import="nablarch.common.dao.EntityList" %>
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
 
 <!--
@@ -34,7 +33,7 @@
     }
   }
 
-  List<Map<String, Object>> result = new ArrayList<Map<String, Object>>() {{
+  EntityList<Map<String, Object>> result = new EntityList<Map<String, Object>>() {{
     add(new HashMap<String, Object>() {{
       put("id", "1001");
       put("name", "なまえ");
@@ -67,6 +66,9 @@
       put("number", 1000000);
       put("code", "value1-2");
     }});
+    setPage(1);
+    setMax(size());
+    setResultCount(size());
   }};
 
   request.setAttribute("result", result);

--- a/node_modules/nablarch-widget-column-label/ui_test/jsp/テーブル/カラムウィジェット_ラベル_テストデータ.jsp
+++ b/node_modules/nablarch-widget-column-label/ui_test/jsp/テーブル/カラムウィジェット_ラベル_テストデータ.jsp
@@ -1,8 +1,7 @@
-<%@ page import="java.util.ArrayList" %>
 <%@ page import="java.util.HashMap" %>
-<%@ page import="java.util.List" %>
 <%@ page import="java.util.Map" %>
 <%@ page import="nablarch.core.db.support.ListSearchInfo" %>
+<%@ page import="nablarch.common.dao.EntityList" %>
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
 <!--
 <%
@@ -32,7 +31,7 @@
     }
   }
 
-  List<Map<String, Object>> result = new ArrayList<Map<String, Object>>() {{
+  EntityList<Map<String, Object>> result = new EntityList<Map<String, Object>>() {{
     add(new HashMap<String, Object>() {{
       put("id", "1001");
       put("name", "なまえ");
@@ -69,6 +68,9 @@
       put("hidden", "000");
       put("status", 0);
     }});
+    setPage(1);
+    setMax(size());
+    setResultCount(size());
   }};
 
   request.setAttribute("result", result);

--- a/node_modules/nablarch-widget-column-link/ui_test/jsp/テーブル/カラムウィジェット_リンク_テストデータ.jsp
+++ b/node_modules/nablarch-widget-column-link/ui_test/jsp/テーブル/カラムウィジェット_リンク_テストデータ.jsp
@@ -1,8 +1,7 @@
-<%@ page import="java.util.ArrayList" %>
 <%@ page import="java.util.HashMap" %>
-<%@ page import="java.util.List" %>
 <%@ page import="java.util.Map" %>
 <%@ page import="nablarch.core.db.support.ListSearchInfo" %>
+<%@ page import="nablarch.common.dao.EntityList" %>
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
 
 <!--
@@ -32,7 +31,7 @@
     }
   }
 
-  List<Map<String, Object>> result = new ArrayList<Map<String, Object>>() {{
+  EntityList<Map<String, Object>> result = new EntityList<Map<String, Object>>() {{
     add(new HashMap<String, Object>() {{
       put("id",     "1001");
       put("name",   "なpまえ");
@@ -65,6 +64,9 @@
       put("number", 1000000);
       put("status", 1);
     }});
+    setPage(1);
+    setMax(size());
+    setResultCount(size());
   }};
 
   request.setAttribute("result", result);

--- a/node_modules/nablarch-widget-column-radio/ui_test/jsp/テーブル/カラムウィジェット_ラジオ_テストデータ.jsp
+++ b/node_modules/nablarch-widget-column-radio/ui_test/jsp/テーブル/カラムウィジェット_ラジオ_テストデータ.jsp
@@ -1,8 +1,7 @@
-<%@ page import="java.util.ArrayList" %>
 <%@ page import="java.util.HashMap" %>
-<%@ page import="java.util.List" %>
 <%@ page import="java.util.Map" %>
 <%@ page import="nablarch.core.db.support.ListSearchInfo" %>
+<%@ page import="nablarch.common.dao.EntityList" %>
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
 
 <!--
@@ -28,7 +27,7 @@
     }
   }
 
-  List<Map<String, Object>> result = new ArrayList<Map<String, Object>>() {{
+  EntityList<Map<String, Object>> result = new EntityList<Map<String, Object>>() {{
     add(new HashMap<String, Object>() {{
       put("id", "1001");
       put("name", "なまえ");
@@ -57,6 +56,9 @@
       put("date", "20131004");
       put("number", 1000000);
     }});
+    setPage(1);
+    setMax(size());
+    setResultCount(size());
   }};
 
   request.setAttribute("result", result);

--- a/node_modules/nablarch-widget-table-base/ui_public/WEB-INF/tags/listSearchResult/listSearchPaging.tag
+++ b/node_modules/nablarch-widget-table-base/ui_public/WEB-INF/tags/listSearchResult/listSearchPaging.tag
@@ -9,6 +9,7 @@
 <%--------------------------------------------------------------
 属性
 --------------------------------------------------------------%>
+<%@ attribute name="resultSetName" required="true" rtexprvalue="true" %>
 <%@ attribute name="listSearchInfoName" required="true" rtexprvalue="true" %>
 <%@ attribute name="pagingCss" required="false" rtexprvalue="true" %>
 <%@ attribute name="searchUri" required="true" rtexprvalue="true" %>
@@ -100,7 +101,11 @@
 本体処理
 --------------------------------------------------------------%>
 <n:set var="listSearchInfo" name="${listSearchInfoName}" scope="page" bySingleValue="false" />
-<c:if test="${listSearchInfo.resultCount != 0}">
+<n:set var="resultSet" name="${resultSetName}" scope="page" bySingleValue="false" />
+<%-- resultSetはListを継承したクラスであるため、EL式ではindex番号以外でのアクセスができない。 --%>
+<%-- そのため、paginationを一旦別変数に保存して使用する。 --%>
+<n:set var="pagination" name="${resultSetName}.pagination" scope="page" />
+<c:if test="${pagination.resultCount != 0}">
 
     <div class="<n:write name='pagingCss' withHtmlFormat='false' />">
         <%-- 現在のページ番号 --%>
@@ -109,7 +114,7 @@
                 <jsp:invoke fragment="currentPageNumberFragment" var="currentPageTag" />
                 <c:if test="${empty currentPageTag}">
                     <span>
-                    [<n:write name="${listSearchInfoName}.pageNumber" />/<n:write name="${listSearchInfoName}.pageCount" />ページ]
+                    [<n:write name="pagination.pageNumber" />/<n:write name="pagination.pageCount" />ページ]
                     </span>
                 </c:if>
                 <c:if test="${not empty currentPageTag}">
@@ -123,10 +128,11 @@
                                 type="${firstSubmitType}"
                                 css="${firstSubmitCss}"
                                 label="${firstSubmitLabel}"
-                                enable="${listSearchInfo.hasPrevPage}"
+                                enable="${pagination.hasPrevPage}"
                                 uri="${searchUri}"
                                 name="${firstSubmitName}${submitNameSuffix}"
-                                pageNumber="${listSearchInfo.firstPageNumber}"
+                                pageNumber="${pagination.firstPageNumber}"
+                                sortId="${listSearchInfo.sortId}"
                                 listSearchInfoName="${listSearchInfoName}" />
         </c:if>
         <%-- 前へ --%>
@@ -135,25 +141,27 @@
                                 type="${prevSubmitType}"
                                 css="${prevSubmitCss}"
                                 label="${prevSubmitLabel}"
-                                enable="${listSearchInfo.hasPrevPage}"
+                                enable="${pagination.hasPrevPage}"
                                 uri="${searchUri}"
                                 name="${prevSubmitName}${submitNameSuffix}"
-                                pageNumber="${listSearchInfo.prevPageNumber}"
+                                pageNumber="${pagination.prevPageNumber}"
+                                sortId="${listSearchInfo.sortId}"
                                 listSearchInfoName="${listSearchInfoName}" />
         </c:if>
         <%--  ページ番号(1 2 3 ...n) --%>
-        <c:if test="${(usePageNumberSubmit == 'true') && (listSearchInfo.pageCount != 1)}">
+        <c:if test="${(usePageNumberSubmit == 'true') && (pagination.pageCount != 1)}">
             <div class="<n:write name='pageNumberSubmitWrapperCss' withHtmlFormat='false' />">
-                <c:forEach begin="1" end="${listSearchInfo.pageCount}" varStatus="status">
+                <c:forEach begin="1" end="${pagination.pageCount}" varStatus="status">
                     <n:set var="pageNumber" value="${status.index}" scope="page" />
                     <listSearchResult:listSearchSubmit tag="${pageNumberSubmitTag}"
                                         type="${pageNumberSubmitType}"
                                         css="${pageNumberSubmitCss}"
                                         label="${pageNumber}"
-                                        enable="${listSearchInfo.pageNumber != pageNumber}"
+                                        enable="${pagination.pageNumber != pageNumber}"
                                         uri="${searchUri}"
                                         name="${pageNumberSubmitName}${pageNumber}${submitNameSuffix}"
                                         pageNumber="${pageNumber}"
+                                        sortId="${listSearchInfo.sortId}"
                                         listSearchInfoName="${listSearchInfoName}" />
                 </c:forEach>
             </div>
@@ -164,10 +172,11 @@
                                 type="${nextSubmitType}"
                                 css="${nextSubmitCss}"
                                 label="${nextSubmitLabel}"
-                                enable="${listSearchInfo.hasNextPage}"
+                                enable="${pagination.hasNextPage}"
                                 uri="${searchUri}"
                                 name="${nextSubmitName}${submitNameSuffix}"
-                                pageNumber="${listSearchInfo.nextPageNumber}"
+                                pageNumber="${pagination.nextPageNumber}"
+                                sortId="${listSearchInfo.sortId}"
                                 listSearchInfoName="${listSearchInfoName}" />
         </c:if>
         <%-- 最後 --%>
@@ -176,10 +185,11 @@
                                 type="${lastSubmitType}"
                                 css="${lastSubmitCss}"
                                 label="${lastSubmitLabel}"
-                                enable="${listSearchInfo.hasNextPage}"
+                                enable="${pagination.hasNextPage}"
                                 uri="${searchUri}"
                                 name="${lastSubmitName}${submitNameSuffix}"
-                                pageNumber="${listSearchInfo.lastPageNumber}"
+                                pageNumber="${pagination.lastPageNumber}"
+                                sortId="${listSearchInfo.sortId}"
                                 listSearchInfoName="${listSearchInfoName}" />
         </c:if>
     </div>

--- a/node_modules/nablarch-widget-table-base/ui_public/WEB-INF/tags/listSearchResult/listSearchResult.tag
+++ b/node_modules/nablarch-widget-table-base/ui_public/WEB-INF/tags/listSearchResult/listSearchResult.tag
@@ -61,6 +61,7 @@
 <%@ attribute name="lastSubmitLabel" required="false" rtexprvalue="true" %>
 <%@ attribute name="lastSubmitName" required="false" rtexprvalue="true" %>
 <%-- 検索結果 --%>
+<%@ attribute name="showResult" required="false" rtexprvalue="true" %>
 <%@ attribute name="resultSetName" required="false" rtexprvalue="true" %>
 <%@ attribute name="resultNumName" required="false" rtexprvalue="true" %>
 <%@ attribute name="resultSetCss" required="false" rtexprvalue="true" %>
@@ -82,6 +83,7 @@
 <%-- 全体ラッパ --%>
 <c:if test="${empty listSearchResultWrapperCss}"><n:set var="listSearchResultWrapperCss" value="nablarch_listSearchResultWrapper" scope="page" /></c:if>
 <c:if test="${empty pagingPosition}"><n:set var="pagingPosition" value="top" scope="page" /></c:if>
+<c:if test="${empty showResult}"><n:set var="showResult" value="true" scope="page" /></c:if>
 <%-- 検索結果件数 --%>
 <c:if test="${empty useResultCount}"><n:set var="useResultCount" value="true" scope="page" /></c:if>
 <c:if test="${empty resultCountCss}"><n:set var="resultCountCss" value="true" scope="page" /></c:if>
@@ -98,17 +100,20 @@
 <c:if test="${not empty resultNumName}">
   <n:set var="resultNum" name="${resultNumName}" scope="page" bySingleValue="false" />
 </c:if>
+<%-- resultSetはListを継承したクラスであるため、EL式ではindex番号以外でのアクセスができない。 --%>
+<%-- そのため、paginationを一旦別変数に保存して使用する。 --%>
+<n:set var="pagination" name="${resultSetName}.pagination" scope="page" />
 <c:if test="${(not empty resultSet)  || (not empty resultNum)}">
 <c:if test="${not empty listSearchInfoName}">
     <n:set var="listSearchInfo" name="${listSearchInfoName}" scope="page" bySingleValue="false" />
 </c:if>
 <div id="<n:write name='id' withHtmlFormat='false' />" class="<n:write name='listSearchResultWrapperCss' withHtmlFormat='false' />">
     <%-- 検索結果件数 --%>
-    <c:if test="${not empty listSearchInfo && (useResultCount == 'true')}">
+    <c:if test="${not empty resultSet && (useResultCount == 'true')}">
     <jsp:invoke fragment="resultCountFragment" var="resultCountTag" />
     <div class="<n:write name='resultCountCss' withHtmlFormat='false' />">
         <c:if test="${empty resultCountTag}">
-            検索結果 <n:write name="${listSearchInfoName}.resultCount" />件
+            検索結果 <n:write name="pagination.resultCount" />件
         </c:if>
         <c:if test="${not empty resultCountTag}">
             <jsp:invoke fragment="resultCountFragment" />
@@ -116,8 +121,9 @@
     </div>
     </c:if>
     <%-- ページング(top) --%>
-    <c:if test="${(not empty listSearchInfo && (usePaging == 'true')) && ((pagingPosition == 'top') || (pagingPosition == 'both'))}">
-    <listSearchResult:listSearchPaging listSearchInfoName="${listSearchInfoName}"
+    <c:if test="${(not empty resultSetName && not empty listSearchInfo && (usePaging == 'true')) && ((pagingPosition == 'top') || (pagingPosition == 'both'))}">
+    <listSearchResult:listSearchPaging resultSetName="${resultSetName}"
+                        listSearchInfoName="${listSearchInfoName}"
                         pagingCss="${pagingCss}"
                         searchUri="${searchUri}"
                         submitNameSuffix="_top"
@@ -157,30 +163,33 @@
     </listSearchResult:listSearchPaging>
     </c:if>
     <%-- 検索結果 --%>
-    <c:if test="${not empty listSearchInfo}">
-        <n:set var="startPosition" value="${listSearchInfo.startPosition}" scope="page" />
+    <c:if test="${showResult}">
+        <c:if test="${not empty resultSet}">
+            <n:set var="startPosition" value="${pagination.startPosition}" scope="page" />
+        </c:if>
+        <c:if test="${empty resultSet}">
+            <n:set var="startPosition" value="1" scope="page" />
+        </c:if>
+        <listSearchResult:table
+                 resultSetName="${resultSetName}"
+                 resultNumName="${resultNumName}"
+                 resultSetCss="${resultSetCss}"
+                 varRowName="${varRowName}"
+                 varStatusName="${varStatusName}"
+                 varCountName="${varCountName}"
+                 varRowCountName="${varRowCountName}"
+                 varOddEvenName="${varOddEvenName}"
+                 oddValue="${oddValue}"
+                 evenValue="${evenValue}"
+                 startPosition="${startPosition}">
+            <jsp:attribute name="headerRowFragment"><jsp:invoke fragment="headerRowFragment" /></jsp:attribute>
+            <jsp:attribute name="bodyRowFragment"><jsp:invoke fragment="bodyRowFragment" /></jsp:attribute>
+        </listSearchResult:table>
     </c:if>
-    <c:if test="${empty listSearchInfo}">
-        <n:set var="startPosition" value="1" scope="page" />
-    </c:if>
-    <listSearchResult:table
-             resultSetName="${resultSetName}"
-             resultNumName="${resultNumName}"
-             resultSetCss="${resultSetCss}"
-             varRowName="${varRowName}"
-             varStatusName="${varStatusName}"
-             varCountName="${varCountName}"
-             varRowCountName="${varRowCountName}"
-             varOddEvenName="${varOddEvenName}"
-             oddValue="${oddValue}"
-             evenValue="${evenValue}"
-             startPosition="${startPosition}">
-        <jsp:attribute name="headerRowFragment"><jsp:invoke fragment="headerRowFragment" /></jsp:attribute>
-        <jsp:attribute name="bodyRowFragment"><jsp:invoke fragment="bodyRowFragment" /></jsp:attribute>
-    </listSearchResult:table>
     <%-- ページング(bottom) --%>
-    <c:if test="${(not empty listSearchInfo && (usePaging == 'true')) && ((pagingPosition == 'bottom') || (pagingPosition == 'both'))}">
-    <listSearchResult:listSearchPaging listSearchInfoName="${listSearchInfoName}"
+    <c:if test="${(not empty resultSetName && not empty listSearchInfo && (usePaging == 'true')) && ((pagingPosition == 'bottom') || (pagingPosition == 'both'))}">
+    <listSearchResult:listSearchPaging resultSetName="${resultSetName}"
+                        listSearchInfoName="${listSearchInfoName}"
                         pagingCss="${pagingCss}"
                         searchUri="${searchUri}"
                         submitNameSuffix="_bottom"

--- a/node_modules/nablarch-widget-table-plain/ui_test/jsp/テーブル/一覧テーブル_テストデータ.jsp
+++ b/node_modules/nablarch-widget-table-plain/ui_test/jsp/テーブル/一覧テーブル_テストデータ.jsp
@@ -4,6 +4,7 @@
 <%@ page import="java.util.HashMap" %>
 <%@ page import="java.util.List" %>
 <%@ page import="java.util.Map" %>
+<%@ page import="nablarch.common.dao.EntityList" %>
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
 
 <!--
@@ -12,7 +13,7 @@
   // サーバーモードを表す
   request.setAttribute("serverMode", true);
 
-  List<Map<String, Object>> result = new ArrayList<Map<String, Object>>() {{
+  EntityList<Map<String, Object>> result = new EntityList<Map<String, Object>>() {{
     add(new HashMap<String, Object>() {{
       put("id", "1001");
       put("name", "なまえ");
@@ -41,11 +42,14 @@
       put("date", "20131004");
       put("number", 1000000);
     }});
+    setPage(1);
+    setMax(size());
+    setResultCount(size());
   }};
 
   request.setAttribute("result", result);
   request.setAttribute("resultNum", 3);
-  final List<Map<String, Object>> resultForNoId = result;
+  final EntityList<Map<String, Object>> resultForNoId = result;
   request.setAttribute("for", new HashMap<String, HashMap<String, List<Map<String, Object>>>>() {{
                      put("noId", new HashMap<String, List<Map<String, Object>>>(){{
                        put("result", resultForNoId);

--- a/node_modules/nablarch-widget-table-row/ui_test/jsp/テーブル/複数行レイアウト/サーバークライアント共通_テストデータ.jsp
+++ b/node_modules/nablarch-widget-table-row/ui_test/jsp/テーブル/複数行レイアウト/サーバークライアント共通_テストデータ.jsp
@@ -1,7 +1,6 @@
-<%@ page import="java.util.ArrayList" %>
 <%@ page import="java.util.HashMap" %>
-<%@ page import="java.util.List" %>
 <%@ page import="java.util.Map" %>
+<%@ page import="nablarch.common.dao.EntityList" %>
 <%@ page import="nablarch.core.db.support.ListSearchInfo" %>
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
 
@@ -34,7 +33,7 @@
     }
   }
 
-  List<Map<String, Object>> result = new ArrayList<Map<String, Object>>() {{
+  EntityList<Map<String, Object>> result = new EntityList<Map<String, Object>>() {{
     add(new HashMap<String, Object>() {{
       put("id", "1001");
       put("name", "なまえ");
@@ -67,6 +66,9 @@
       put("number", 1000000);
       put("code", "value1-2");
     }});
+    setPage(1);
+    setMax(size());
+    setResultCount(size());
   }};
 
   request.setAttribute("result", result);

--- a/node_modules/nablarch-widget-table-search_result/ui_test/jsp/テーブル/検索結果表示用テーブル_テストデータ.jsp
+++ b/node_modules/nablarch-widget-table-search_result/ui_test/jsp/テーブル/検索結果表示用テーブル_テストデータ.jsp
@@ -1,9 +1,8 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
-<%@ page import="java.util.ArrayList" %>
 <%@ page import="java.util.HashMap" %>
-<%@ page import="java.util.List" %>
 <%@ page import="java.util.Map" %>
 <%@ page import="nablarch.core.db.support.ListSearchInfo" %>
+<%@ page import="nablarch.common.dao.EntityList" %>
 <!--
 <%!
   class ListSearchInfoImpl extends ListSearchInfo {
@@ -35,8 +34,8 @@
     return listSearchInfo;
   }
 
-  List<Map<String, Object>> makePageData(final int pageNo, final int count) {
-    return new ArrayList<Map<String, Object>>() {{
+  EntityList<Map<String, Object>> makePageData(final int pageNo, final int count, final int per, final int total) {
+     EntityList<Map<String, Object>> result = new EntityList<Map<String, Object>>() {{
       for (int i = 1; i <= count; i++) {
         final int finalI = i;
         add(new HashMap<String, Object>() {{
@@ -44,7 +43,11 @@
           put("name", String.format("%sページ目 なまえ%d", pageNo, finalI));
         }});
       }
+      setPage(pageNo);
+      setMax(per);
+      setResultCount(total);
     }};
+    return result;
   }
 %>
 <%
@@ -52,53 +55,53 @@
   // サーバーモードを表す
   request.setAttribute("serverMode", true);
 
-  List<Map<String, Object>> searchResult;
+  EntityList<Map<String, Object>> searchResult;
   ListSearchInfoImpl listSearchInfo = new ListSearchInfoImpl();
   if (!request.getParameterMap().containsKey("searchInfo.pageNumber") || request.getParameter("searchInfo.pageNumber")
       .equals("1")) {
     // 1ページ目
     request.setAttribute("searchInfo", makeListSearchInfo(1, 4));
-    request.setAttribute("searchResult", makePageData(1, 2));
+    request.setAttribute("searchResult", makePageData(1, 2, 2, 4));
   } else if (request.getParameter("searchInfo.pageNumber").equals("2")) {
     // 2ページ目
     request.setAttribute("searchInfo", makeListSearchInfo(2, 4));
-    request.setAttribute("searchResult", makePageData(2, 2));
+    request.setAttribute("searchResult", makePageData(2, 2, 2, 4));
   }
 
   if (!request.getParameterMap().containsKey("searchInfo-usePaging-blank.pageNumber") || request.getParameter(
       "searchInfo-usePaging-blank.pageNumber").equals("1")) {
     // 1ページ目
     request.setAttribute("searchInfo-usePaging-blank", makeListSearchInfo(1, 3));
-    request.setAttribute("searchResult-usePaging-blank", makePageData(1, 2));
+    request.setAttribute("searchResult-usePaging-blank", makePageData(1, 2, 2, 3));
   } else if (request.getParameter("searchInfo-usePaging-blank.pageNumber").equals("2")) {
     // 2ページ目
     request.setAttribute("searchInfo-usePaging-blank", makeListSearchInfo(2, 3));
-    request.setAttribute("searchResult-usePaging-blank", makePageData(2, 1));
+    request.setAttribute("searchResult-usePaging-blank", makePageData(2, 1, 2, 3));
   }
 
   if (!request.getParameterMap().containsKey("searchInfo-usePaging-true.pageNumber") || request.getParameter(
       "searchInfo-usePaging-true.pageNumber").equals("1")) {
     // 1ページ目
     request.setAttribute("searchInfo-usePaging-true", makeListSearchInfo(1, 7, 3));
-    request.setAttribute("searchResult-usePaging-true", makePageData(1, 3));
+    request.setAttribute("searchResult-usePaging-true", makePageData(1, 3, 3, 7));
   } else if (request.getParameter("searchInfo-usePaging-true.pageNumber").equals("2")) {
     // 2ページ目
     request.setAttribute("searchInfo-usePaging-true", makeListSearchInfo(2, 7, 3));
-    request.setAttribute("searchResult-usePaging-true", makePageData(2, 3));
+    request.setAttribute("searchResult-usePaging-true", makePageData(2, 3, 3, 7));
   } else if (request.getParameter("searchInfo-usePaging-true.pageNumber").equals("3")) {
     // 2ページ目
     request.setAttribute("searchInfo-usePaging-true", makeListSearchInfo(3, 7, 3));
-    request.setAttribute("searchResult-usePaging-true", makePageData(3, 1));
+    request.setAttribute("searchResult-usePaging-true", makePageData(3, 1, 3, 7));
   }
 
   if (!request.getParameterMap().containsKey("searchInfo-usePaging-false.pageNumber")) {
     // 1ページ目
     request.setAttribute("searchInfo-usePaging-false", makeListSearchInfo(1, 15, 15));
-    request.setAttribute("searchResult-usePaging-false", makePageData(1, 15));
+    request.setAttribute("searchResult-usePaging-false", makePageData(1, 15, 15, 15));
   }
   if (!request.getParameterMap().containsKey("searchInfo-server-default.pageNumber")) {
     request.setAttribute("searchInfo-server-default", makeListSearchInfo(1, 4));
-    request.setAttribute("searchResult-server-default", makePageData(1, 4));
+    request.setAttribute("searchResult-server-default", makePageData(1, 4, 4, 4));
   }
 %>
 -->

--- a/node_modules/nablarch-widget-table-tree/ui_test/jsp/ツリーリスト/ツリーリスト.jsp
+++ b/node_modules/nablarch-widget-table-tree/ui_test/jsp/ツリーリスト/ツリーリスト.jsp
@@ -8,9 +8,9 @@
 <%@ taglib prefix="table" tagdir="/WEB-INF/tags/widget/table" %>
 <%@ taglib prefix="column" tagdir="/WEB-INF/tags/widget/column" %>
 <%@ taglib prefix="t" tagdir="/WEB-INF/tags/template" %>
-<%@ page import="java.util.ArrayList" %>
 <%@ page import="java.util.HashMap" %>
 <%@ page import="java.util.Map" %>
+<%@ page import="nablarch.common.dao.EntityList" %>
 <%@ page import="nablarch.core.db.support.ListSearchInfo" %>
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
 
@@ -19,7 +19,7 @@
   // サーバーモードを表す
   request.setAttribute("serverMode", true);
 
-  request.setAttribute("searchResult", new ArrayList<Map<String, String>>() {{
+  request.setAttribute("searchResult", new EntityList<Map<String, String>>() {{
     add(new HashMap<String, String>() {{
       put("rid", "RW11AA0101");
       put("name", "ログイン画面初期表示処理");
@@ -108,8 +108,11 @@
       put("rid", "RW11AC03");
       put("name", "ユーザ情報更新");
     }});
+    setPage(1);
+    setMax(size());
+    setResultCount(size());
   }});
-  request.setAttribute("searchResult2", new ArrayList<Map<String, String>>() {{
+  request.setAttribute("searchResult2", new EntityList<Map<String, String>>() {{
     add(new HashMap<String, String>() {{
       put("rid", "RW11AA_1_1");
       put("name", "ログイン画面初期表示処理");
@@ -198,6 +201,9 @@
       put("rid", "RW11AC_3");
       put("name", "ユーザ情報更新");
     }});
+    setPage(1);
+    setMax(size());
+    setResultCount(size());
   }});
 
   request.setAttribute("searchInfo", new ListSearchInfo() {

--- a/node_modules/nablarch-widget-table-tree/ui_test/jsp/ツリーリスト/ツリーリスト_性能.jsp
+++ b/node_modules/nablarch-widget-table-tree/ui_test/jsp/ツリーリスト/ツリーリスト_性能.jsp
@@ -8,10 +8,10 @@
 <%@ taglib prefix="table" tagdir="/WEB-INF/tags/widget/table" %>
 <%@ taglib prefix="column" tagdir="/WEB-INF/tags/widget/column" %>
 <%@ taglib prefix="t" tagdir="/WEB-INF/tags/template" %>
-<%@ page import="java.util.ArrayList" %>
 <%@ page import="java.util.List" %>
 <%@ page import="java.util.HashMap" %>
 <%@ page import="java.util.Map" %>
+<%@ page import="nablarch.common.dao.EntityList" %>
 <%@ page import="nablarch.core.db.support.ListSearchInfo" %>
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
 
@@ -20,12 +20,15 @@
   // サーバーモードを表す
   request.setAttribute("serverMode", true);
   final class Create {
-    List<Map<String, String>> listMap(int size) {
-      List<Map<String, String>> list = new ArrayList<Map<String, String>>(){{
+    List<Map<String, String>> listMap(final int size) {
+      List<Map<String, String>> list = new EntityList<Map<String, String>>(){{
         add(new HashMap<String, String>(){{
             put("rid", "RW11AA_1");
             put("name", "性能テスト");
         }});
+        setPage(1);
+        setMax(size);
+        setResultCount(size);
       }};
       for (int i = 1; i < size; i++) {
         Map<String, String> map = new HashMap<String, String>();

--- a/node_modules/nablarch-widget-table-tree/ui_test/jsp/ツリーリスト/テストデータ_テーブル検索結果.jsp
+++ b/node_modules/nablarch-widget-table-tree/ui_test/jsp/ツリーリスト/テストデータ_テーブル検索結果.jsp
@@ -1,9 +1,10 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
 <%@ page import="java.util.*" %>
-<%@ page import="java.util.*, nablarch.core.db.support.*" %>
+<%@ page import="nablarch.common.dao.EntityList" %>
+<%@ page import="nablarch.core.db.support.*" %>
 
 <%
-  request.setAttribute("searchResult",  new ArrayList() {{
+  request.setAttribute("searchResult",  new EntityList() {{
     add(new HashMap() {{
       put("id",     "RW11AA0101");
       put("name",   "ログイン画面初期表示処理");
@@ -92,8 +93,11 @@
       put("id",     "RW11AC03");
       put("name",   "ユーザ情報更新");
     }});
+    setPage(1);
+    setMax(size());
+    setResultCount(size());
   }});
-  request.setAttribute("searchResult2",  new ArrayList() {{
+  request.setAttribute("searchResult2",  new EntityList() {{
     add(new HashMap() {{
       put("id",     "RW11AA_1_1");
       put("name",   "ログイン画面初期表示処理");
@@ -182,8 +186,11 @@
       put("id",     "RW11AC_3");
       put("name",   "ユーザ情報更新");
     }});
+    setPage(1);
+    setMax(size());
+    setResultCount(size());
   }});
-  request.setAttribute("searchResult3",  new ArrayList() {{
+  request.setAttribute("searchResult3",  new EntityList() {{
     add(new HashMap() {{
       put("id",     "32");
       put("name",   "ログイン画面初期表示処理");
@@ -260,6 +267,9 @@
       put("id",     "10001_");
       put("name",   "10001～");
     }});
+    setPage(1);
+    setMax(size());
+    setResultCount(size());
   }});
   
   request.setAttribute("searchInfo",   new ListSearchInfo() {


### PR DESCRIPTION
listSearchResultタグをUniversalDaoの検索結果をそのまま表示できるよう修正

* UniversalDaoの検索結果 EntityListのpaginationからページ情報を参照するよう変更
* ListSearchInfoは不要となったため、除外

NAB-116