### PR TITLE
jquery.noConflictで脆弱性のあるバージョンに依存しなくてもよくなるように修正

### DIFF
--- a/node_modules/nablarch-dev-ui_test-support/package.json
+++ b/node_modules/nablarch-dev-ui_test-support/package.json
@@ -1,6 +1,6 @@
 { "name": "nablarch-dev-ui_test-support"
 , "description": "UI部品単体テストサポートプラグイン"
-, "version": "1.2.0"
-, "_from" : "nablarch-dev-ui_test-support@1.2.0"
+, "version": "1.2.1"
+, "_from" : "nablarch-dev-ui_test-support@1.2.1"
 , "dependencies": {}
 }

--- a/node_modules/nablarch-dev-ui_test-support/ui_test/WEB-INF/tags/template/ui_test_template.tag
+++ b/node_modules/nablarch-dev-ui_test-support/ui_test/WEB-INF/tags/template/ui_test_template.tag
@@ -92,6 +92,11 @@
   <jsp:attribute name="localInclude">
     <c:if test="${not empty testcase}">
       <n:link rel="stylesheet" type="text/css" href="/css/qunit.css" charset="UTF-8" />
+      <n:script type="text/javascript" src="/js/jquery.js" />
+      <n:script type="text/javascript">
+        // noConflict後にテスト側でグローバルに展開するため、一時退避する
+        window.test_back$ = jQuery;
+      </n:script>
       <n:script type="text/javascript" src="/js/qunit.js" />
       <n:script type="text/javascript" src="/js/runner.js" />
       <n:script type="text/javascript" src="/js/testsupport.js" />

--- a/node_modules/nablarch-dev-ui_test-support/ui_test/js/runner.js
+++ b/node_modules/nablarch-dev-ui_test-support/ui_test/js/runner.js
@@ -3,6 +3,8 @@ function runTest(/*testcasees...*/) {
   
   setTimeout(function() {
     testcases.each(function(testcase) {
+      // globalなjqueryを復元
+      window.$ = window.test_back$
       QUnit.test(nameOf(testcase), testcase);
     });
   }, 3000);

--- a/node_modules/nablarch-dev-ui_test-support/ui_test/js/runner.js
+++ b/node_modules/nablarch-dev-ui_test-support/ui_test/js/runner.js
@@ -4,7 +4,9 @@ function runTest(/*testcasees...*/) {
   setTimeout(function() {
     testcases.each(function(testcase) {
       // globalなjqueryを復元
-      window.$ = window.test_back$
+      if (window.$ === undefined) {
+        window.$ = window.test_back$
+      }
       QUnit.test(nameOf(testcase), testcase);
     });
   }, 3000);

--- a/node_modules/nablarch-widget-core/package.json
+++ b/node_modules/nablarch-widget-core/package.json
@@ -1,7 +1,7 @@
 { "name": "nablarch-widget-core"
 , "description": "Nablarch UIウィジェット 基盤JS部品"
-, "version": "1.0.0"
-, "_from" : "nablarch-widget-core@1.0.0"
+, "version": "1.0.1"
+, "_from" : "nablarch-widget-core@1.0.1"
 , "dependencies":
   { "sugar" : "1.4.1"
   , "jquery"  : "1.11.0"

--- a/node_modules/nablarch-widget-core/ui_public/js/jquery-private.js
+++ b/node_modules/nablarch-widget-core/ui_public/js/jquery-private.js
@@ -1,0 +1,3 @@
+define(["jquery"], function($){"use strict";
+  return $.noConflict(true);
+});

--- a/node_modules/nablarch-widget-core/ui_public/js/nablarch.js
+++ b/node_modules/nablarch-widget-core/ui_public/js/nablarch.js
@@ -16,7 +16,11 @@
 
   // requireJS 初期設定
   require.config({
-    baseUrl: scriptDir
+    baseUrl: scriptDir,
+    map: {
+      '*': { 'jquery': 'jquery-private' },
+      'jquery-private': { 'jquery': 'jquery' }
+    }
   });
 
   // 初期ロード対象コンポーネント

--- a/node_modules/nablarch-widget-tooltip/package.json
+++ b/node_modules/nablarch-widget-tooltip/package.json
@@ -1,6 +1,6 @@
 { "name": "nablarch-widget-tooltip"
   , "description": "ツールチップを表示するプラグイン"
-  , "version": "1.0.0"
-  , "_from" : "nablarch-widget-tooltip@1.0.0"
+  , "version": "1.0.1"
+  , "_from" : "nablarch-widget-tooltip@1.0.1"
   , "dependencies": {}
 }

--- a/node_modules/nablarch-widget-tooltip/ui_public/js/jquery.cluetip.js
+++ b/node_modules/nablarch-widget-tooltip/ui_public/js/jquery.cluetip.js
@@ -5,8 +5,7 @@
  * Licensed MIT (http://www.opensource.org/licenses/mit-license.php)
  */
 
-(function($) {
-
+define(["jquery"], function($) {
   $.cluetip = {
     version: '1.2.10',
 
@@ -885,4 +884,4 @@
 
   $.fn.cluetip.defaults = $.cluetip.defaults;
 
-})(jQuery);
+});


### PR DESCRIPTION
no-conflict対応のため、requireの定義やcluetipを修正。
また、テストページではjQueryをグローバルにするための仕組みを導入。
このため、nablarch-widget-coreを取り込む際は必ずテストFWも導入してもらう必要がある。