### PR TITLE
nablarch-dev-ui_demo-core-libが依存するモジュールのバージョンを修正

### DIFF
--- a/node_modules/nablarch-dev-ui_demo-core-lib/package.json
+++ b/node_modules/nablarch-dev-ui_demo-core-lib/package.json
@@ -1,8 +1,8 @@
 { "name": "nablarch-dev-ui_demo-core-lib"
 , "description": "JSPローカル表示のコアライブラリ"
-, "version": "1.1.1"
-, "_from" : "nablarch-dev-ui_demo-core-lib@1.1.1"
+, "version": "1.1.2"
+, "_from" : "nablarch-dev-ui_demo-core-lib@1.1.2"
 , "dependencies": {
-    "nablarch-dev-ui_demo-core" : "1.0.2"
+    "nablarch-dev-ui_demo-core" : "1.0.3"
   }
 }


### PR DESCRIPTION
## 背景
nablarch-dev-ui_demo-core-lib が依存するモジュールのバージョン番号の更新が行なわれていなかった。  
そのため、Nablarch解説書のUI開発基盤の導入実行中にエラーが出る状態だった。

## やったこと
- 依存するモジュールのバージョン番号のアップ
- nablarch-dev-ui_demo-core-libのバージョン番号のアップ
  ※nablarch-dev-ui_demo-core-libの依存が記載されているpackage.jsonは存在しないため、nablarch-dev-ui_demo-core-libのバージョン番号アップに伴って修正が必要なファイルはnablarch-plugins-bundle内には無い。

## 確認したこと
- Nablarch解説書の「UI開発基盤の導入」手順実行時にエラーがでないこと。
- Nablarch解説書の「UI開発基盤の導入」に記載の「UIローカルデモ用プロジェクトの動作確認」と「UI開発基盤テスト用プロジェクトの動作確認」の手順が実行でき、画面がレンダリングされること。

※ 対応はhttps://github.com/nablarch/nablarch-ui-development-template/pull/10 の確認と合わせて行なった。